### PR TITLE
Fix restart on timeboost send failures

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -299,6 +299,7 @@ async fn main() -> eyre::Result<()> {
                                 if supervisor.should_restart(&task_type) {
                                     failed_tasks.push(task_type.clone());
                                     should_restart = true;
+                                    break;
                                 } else {
                                     tracing::error!("{} task exceeded maximum restart attempts", task_type);
                                     break;


### PR DESCRIPTION
## Summary
- log errors when fetching timeboost bids
- break out of supervisor loop so failed tasks restart immediately

## Testing
- `cargo check`
- `cargo test` *(fails: Codex couldn't run certain commands due to environnment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_68414018ccdc832f8e8c08753517d25b