### PR TITLE
Support YAML-based symbols config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2296,6 +2296,7 @@ dependencies = [
  "moka",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
@@ -4611,6 +4612,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.9.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serdect"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5277,6 +5291,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ futures = "0.3.31"
 moka = { version = "0.12.10", features = ["sync"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+serde_yaml = "0.9"
 tempfile = "3.14.0"
 thiserror = "2.0.12"
 tokio = { version = "1.45.0", features = ["full", "tracing"] }

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+use eyre::WrapErr;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SymbolsConfigEntry {
+    pub exchange: String,
+    pub market: String,
+    pub symbols: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SymbolsConfig {
+    pub entries: Vec<SymbolsConfigEntry>,
+}
+
+impl SymbolsConfig {
+    pub fn from_yaml<R: std::io::Read>(reader: R) -> eyre::Result<Self> {
+        let entries: Vec<SymbolsConfigEntry> =
+            serde_yaml::from_reader(reader).wrap_err("Failed to parse YAML")?;
+        Ok(Self { entries })
+    }
+}

--- a/symbols.yaml
+++ b/symbols.yaml
@@ -1,0 +1,9 @@
+- exchange: "Binance"
+  market: "SPOT"
+  symbols:
+    - BTCUSDT
+    - ETHBTC
+- exchange: "OKX"
+  market: "SPOT"
+  symbols:
+    - BTCUSDT


### PR DESCRIPTION
## Summary
- use YAML for symbols configuration
- parse YAML via new `SymbolsConfig` and its `from_yaml` helper
- update CLI default to `symbols.yaml`
- add sample `symbols.yaml`
- read YAML once and filter Binance symbols in `main`

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68414a927460832f922ab7acbb07b7eb