### PR TITLE
Add subcommand to fetch Binance SPOT symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,6 +1692,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,6 +2265,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,6 +2310,7 @@ dependencies = [
  "futures",
  "moka",
  "rand 0.9.1",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2565,8 +2581,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2576,9 +2594,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2868,6 +2888,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
+ "webpki-roots 1.0.0",
 ]
 
 [[package]]
@@ -3325,6 +3346,12 @@ checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.3",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
@@ -3888,6 +3915,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quinn"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.27",
+ "socket2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.2",
+ "lru-slab",
+ "rand 0.9.1",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.27",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.12",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4067,12 +4149,15 @@ checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2 0.4.10",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
+ "hyper-rustls 0.27.6",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -4083,19 +4168,25 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.27",
  "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.26.2",
  "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 0.26.11",
  "windows-registry",
 ]
 
@@ -4320,6 +4411,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4870,6 +4962,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5002,6 +5115,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -5504,6 +5632,16 @@ name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,4 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 url = "2.5.4"
 uuid = { version = "1.4", features = ["v4"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"] }

--- a/src/clickhouse.rs
+++ b/src/clickhouse.rs
@@ -231,6 +231,7 @@ impl ClickHouseService {
 
         let mut inserter = self.get_inserter("cex.trading_pairs", 1000, 1, 0.1)?;
         for pair in pairs {
+            tracing::trace!(pair = %pair.pair, base = %pair.base_asset, quote = %pair.quote_asset, "writing trading pair");
             inserter.write(&pair)?;
         }
         inserter.commit().await?;

--- a/src/clickhouse.rs
+++ b/src/clickhouse.rs
@@ -224,6 +224,20 @@ impl ClickHouseService {
         Ok(())
     }
 
+    pub async fn write_trading_pairs(&self, pairs: Vec<crate::symbols::TradingPair>) -> eyre::Result<()> {
+        if pairs.is_empty() {
+            return Ok(());
+        }
+
+        let mut inserter = self.get_inserter("cex.trading_pairs", 1000, 1, 0.1)?;
+        for pair in pairs {
+            inserter.write(&pair)?;
+        }
+        inserter.commit().await?;
+        inserter.end().await?;
+        Ok(())
+    }
+
     #[allow(dead_code)]
     pub async fn write_events(
         &self,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use crate::symbols::{
     SymbolsConfig,
     SymbolsConfigEntry,
-    fetch_binance_spot_pairs,
+    fetch_binance_top_spot_pairs,
 };
 use clap::{Args, Parser, Subcommand};
 use dotenv::dotenv;
@@ -224,8 +224,8 @@ async fn main() -> eyre::Result<()> {
                 return Ok(());
             }
             DbCommands::FetchBinanceSymbols(args) => {
-                tracing::info!("Fetching Binance SPOT symbols");
-                let pairs = fetch_binance_spot_pairs().await?;
+                tracing::info!("Fetching top Binance SPOT symbols");
+                let pairs = fetch_binance_top_spot_pairs(200).await?;
                 let symbols: Vec<String> = pairs.iter().map(|p| p.pair.clone()).collect();
                 let cfg = SymbolsConfig {
                     entries: vec![SymbolsConfigEntry {

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ enum Commands {
 enum DbCommands {
     /// Backfill timeboost bids
     Timeboost,
-    /// Fetch Binance SPOT symbols
+    /// Fetch top Binance SPOT symbols by volume
     FetchBinanceSymbols(FetchBinanceSymbolsArgs),
 }
 
@@ -217,7 +217,7 @@ async fn main() -> eyre::Result<()> {
                 return Ok(());
             }
             DbCommands::FetchBinanceSymbols(args) => {
-                tracing::info!("Fetching Binance SPOT symbols");
+                tracing::info!("Fetching top Binance SPOT symbols by volume");
                 let symbols = fetch_binance_spot_symbols().await?;
                 let cfg = SymbolsConfig {
                     entries: vec![SymbolsConfigEntry {

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,9 @@ struct FetchBinanceSymbolsArgs {
     /// Also insert trading pairs into ClickHouse
     #[arg(long)]
     update_clickhouse: bool,
+
+    #[arg(long)]
+    limit: usize,
 }
 
 #[derive(Args, Clone)]
@@ -225,7 +228,7 @@ async fn main() -> eyre::Result<()> {
             }
             DbCommands::FetchBinanceSymbols(args) => {
                 tracing::info!("Fetching top Binance SPOT symbols");
-                let pairs = fetch_binance_top_spot_pairs(200).await?;
+                let pairs = fetch_binance_top_spot_pairs(args.limit).await?;
                 let symbols: Vec<String> = pairs.iter().map(|p| p.pair.clone()).collect();
                 let cfg = SymbolsConfig {
                     entries: vec![SymbolsConfigEntry {

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -1,5 +1,6 @@
 use eyre::WrapErr;
 use serde::{Deserialize, Serialize};
+use clickhouse::Row;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SymbolsConfigEntry {
@@ -36,18 +37,24 @@ struct BinanceSymbolInfo {
     status: String,
     #[serde(rename = "permissionSets")]
     permission_sets: Option<Vec<Vec<String>>>,
+    #[serde(rename = "baseAsset")]
+    base_asset: String,
+    #[serde(rename = "quoteAsset")]
+    quote_asset: String,
 }
 
-#[derive(Debug, Deserialize)]
-struct BinanceTickerInfo {
-    symbol: String,
-    #[serde(rename = "quoteVolume")]
-    quote_volume: String,
+
+#[derive(Debug, Clone, Row, Serialize, Deserialize)]
+pub struct TradingPair {
+    pub exchange: String,
+    pub trading_type: String,
+    pub pair: String,
+    pub base_asset: String,
+    pub quote_asset: String,
 }
 
-pub async fn fetch_binance_spot_symbols() -> eyre::Result<Vec<String>> {
-    const EXCHANGE_INFO_URL: &str = "https://data-api.binance.vision/api/v3/exchangeInfo";
-    const TICKER_URL: &str = "https://data-api.binance.vision/api/v3/ticker/24hr";
+pub async fn fetch_binance_spot_pairs() -> eyre::Result<Vec<TradingPair>> {
+    const EXCHANGE_INFO_URL: &str = "https://api.binance.com/api/v3/exchangeInfo";
 
     let client = reqwest::Client::new();
 
@@ -59,43 +66,42 @@ pub async fn fetch_binance_spot_symbols() -> eyre::Result<Vec<String>> {
         .json()
         .await?;
 
-    use std::collections::HashSet;
-    let mut spot: HashSet<String> = info
-        .symbols
-        .into_iter()
-        .filter(|s| {
-            if s.status != "TRADING" {
-                return false;
-            }
-            if let Some(psets) = &s.permission_sets {
-                if let Some(first) = psets.get(0) {
-                    return first.iter().any(|p| p == "SPOT");
+    let mut pairs = Vec::new();
+    for sym in info.symbols.into_iter() {
+        if sym.status != "TRADING" {
+            continue;
+        }
+        if let Some(psets) = &sym.permission_sets {
+            if let Some(first) = psets.get(0) {
+                if !first.iter().any(|p| p == "SPOT") {
+                    continue;
                 }
+            } else {
+                continue;
             }
-            false
-        })
-        .map(|s| s.symbol)
-        .collect();
+        } else {
+            continue;
+        }
 
-    let tickers: Vec<BinanceTickerInfo> = client
-        .get(TICKER_URL)
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+        pairs.push(TradingPair {
+            exchange: "binance".to_string(),
+            trading_type: "SPOT".to_string(),
+            pair: sym.symbol,
+            base_asset: sym.base_asset,
+            quote_asset: sym.quote_asset,
+        });
+    }
 
-    let mut entries: Vec<(String, f64)> = tickers
-        .into_iter()
-        .filter(|t| spot.contains(&t.symbol))
-        .map(|t| {
-            let vol = t.quote_volume.parse::<f64>().unwrap_or(0.0);
-            (t.symbol, vol)
-        })
-        .collect();
+    Ok(pairs)
+}
 
-    entries.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-    entries.truncate(200);
-
-    Ok(entries.into_iter().map(|(s, _)| s).collect())
+#[allow(dead_code)]
+pub async fn fetch_binance_spot_symbols() -> eyre::Result<Vec<String>> {
+    Ok(
+        fetch_binance_spot_pairs()
+            .await?
+            .into_iter()
+            .map(|p| p.pair)
+            .collect(),
+    )
 }


### PR DESCRIPTION
## Summary
- add `reqwest` dependency
- implement YAML writing and Binance spot symbol fetch logic
- introduce `db fetch-binance-symbols` subcommand

## Testing
- `cargo test --no-run --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6842ae2203b8832fb0e42ef9646565c2