### PR TITLE
Add Kucoin exchange support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use crate::{
     models::{ClickhouseMessage, NormalizedEvent},
     streams::{
         ExchangeStreamError, WebsocketStream, binance::BinanceClient, bybit::BybitClient,
-        coinbase::CoinbaseClient, okx::OkxClient,
+        coinbase::CoinbaseClient, okx::OkxClient, kucoin::KucoinClient,
     },
 };
 
@@ -102,6 +102,10 @@ struct StreamArgs {
     #[arg(long)]
     skip_coinbase: bool,
 
+    /// Skip KuCoin stream
+    #[arg(long)]
+    skip_kucoin: bool,
+
     /// Skip Ethereum block metadata
     #[arg(long)]
     skip_ethereum: bool,
@@ -141,6 +145,7 @@ enum TaskType {
     BybitStream,
     OkxStream,
     CoinbaseStream,
+    KucoinStream,
     EthereumBlockMetadata,
     ClickHouseInsert,
     FetchTimeboostBids,
@@ -152,6 +157,7 @@ impl std::fmt::Display for TaskType {
             TaskType::BinanceStream => write!(f, "Binance"),
             TaskType::BybitStream => write!(f, "Bybit"),
             TaskType::CoinbaseStream => write!(f, "Coinbase"),
+            TaskType::KucoinStream => write!(f, "KuCoin"),
             TaskType::EthereumBlockMetadata => write!(f, "Ethereum"),
             TaskType::ClickHouseInsert => write!(f, "ClickHouse"),
             TaskType::FetchTimeboostBids => write!(f, "Timeboost"),
@@ -285,6 +291,8 @@ async fn run_stream(args: StreamArgs) -> eyre::Result<()> {
     if args.skip_binance
         && args.skip_bybit
         && args.skip_okx
+        && args.skip_coinbase
+        && args.skip_kucoin
         && args.skip_ethereum
         && args.skip_clickhouse
         && args.skip_timeboost
@@ -376,6 +384,26 @@ async fn run_stream(args: StreamArgs) -> eyre::Result<()> {
                 (
                     TaskType::CoinbaseStream,
                     coinbase_stream_task(tx, symbols, batch_size).await,
+                )
+            });
+        }
+
+        if !args.skip_kucoin {
+            let config = read_symbols(&args.symbols_file)?;
+            let symbols: Vec<String> = config
+                .entries
+                .iter()
+                .filter(|e| e.exchange.eq_ignore_ascii_case("kucoin"))
+                .flat_map(|e| e.symbols.iter().cloned())
+                .collect();
+            let batch_size = args.batch_size;
+            let tx = msg_tx.clone();
+
+            tracing::info!("Spawning kucoin stream for symbols: {:?}", symbols);
+            set.spawn(async move {
+                (
+                    TaskType::KucoinStream,
+                    kucoin_stream_task(tx, symbols, batch_size).await,
                 )
             });
         }
@@ -618,6 +646,41 @@ async fn coinbase_stream_task(
 ) -> eyre::Result<()> {
     let coinbase = CoinbaseClient::builder().add_symbols(symbols).build()?;
     let combined_stream = coinbase.stream_events().await?;
+    let chunks = combined_stream
+        .filter_map(
+            |event: Result<NormalizedEvent, ExchangeStreamError>| async move {
+                match event {
+                    Ok(NormalizedEvent::Trade(trade)) => {
+                        Some(ClickhouseMessage::Cex(NormalizedEvent::Trade(trade)))
+                    }
+                    Ok(NormalizedEvent::Quote(quote)) => {
+                        Some(ClickhouseMessage::Cex(NormalizedEvent::Quote(quote)))
+                    }
+                    Err(e) => {
+                        tracing::error!("Error parsing event: {:?}", e);
+                        None
+                    }
+                }
+            },
+        )
+        .chunks(batch_size);
+    pin_mut!(chunks);
+    while let Some(chunk) = chunks.next().await {
+        let res = evt_tx.send(chunk);
+        if res.is_err() {
+            tracing::error!("Failed to send chunk to channel");
+        }
+    }
+    Ok(())
+}
+
+async fn kucoin_stream_task(
+    evt_tx: mpsc::UnboundedSender<Vec<ClickhouseMessage>>,
+    symbols: Vec<String>,
+    batch_size: usize,
+) -> eyre::Result<()> {
+    let kucoin = KucoinClient::builder().add_symbols(symbols).build().await?;
+    let combined_stream = kucoin.stream_events().await?;
     let chunks = combined_stream
         .filter_map(
             |event: Result<NormalizedEvent, ExchangeStreamError>| async move {

--- a/src/models.rs
+++ b/src/models.rs
@@ -15,6 +15,8 @@ pub enum ExchangeName {
     Coinbase,
     #[serde(rename = "kraken")]
     Kraken,
+    #[serde(rename = "kucoin")]
+    Kucoin,
     #[serde(rename = "upbit")]
     Upbit,
 }
@@ -27,6 +29,7 @@ impl std::fmt::Display for ExchangeName {
             ExchangeName::Okx => write!(f, "okx"),
             ExchangeName::Coinbase => write!(f, "coinbase"),
             ExchangeName::Kraken => write!(f, "kraken"),
+            ExchangeName::Kucoin => write!(f, "kucoin"),
             ExchangeName::Upbit => write!(f, "upbit"),
         }
     }

--- a/src/streams/bybit/parser.rs
+++ b/src/streams/bybit/parser.rs
@@ -43,7 +43,8 @@ impl OrderBook {
 
     fn best_bid(&self) -> Option<(f64, f64)> {
         self.bids
-            .iter().next_back()
+            .iter()
+            .next_back()
             .map(|(p, q)| (p.into_inner(), *q))
     }
 

--- a/src/streams/exchange_stream.rs
+++ b/src/streams/exchange_stream.rs
@@ -62,7 +62,7 @@ where
 
         let handle = tokio::spawn(async move {
             loop {
-                tracing::trace!("Connecting to {}", url);
+                tracing::trace!("Connecting to {}", &url);
                 let (mut ws, response) = tokio_tungstenite::connect_async(&url)
                     .await
                     .map_err(|e| ExchangeStreamError::ConnectionError(e.to_string()))

--- a/src/streams/kucoin/mod.rs
+++ b/src/streams/kucoin/mod.rs
@@ -1,0 +1,165 @@
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::streams::kucoin::parser::KucoinParser;
+use crate::{
+    models::NormalizedEvent,
+    streams::{
+        exchange_stream::ExchangeStream,
+        subscription::KucoinSubscription,
+        ExchangeStreamError, StreamSymbols, StreamType, WebsocketStream,
+    },
+};
+
+use tokio::time::Duration;
+
+pub mod model;
+pub mod parser;
+
+pub struct KucoinClient {
+    base_url: String,
+    subscription: KucoinSubscription,
+}
+
+impl KucoinClient {
+    pub fn builder() -> KucoinClientBuilder {
+        KucoinClientBuilder::default()
+    }
+}
+
+#[async_trait]
+impl WebsocketStream for KucoinClient {
+    type Error = ExchangeStreamError;
+    type EventStream = ExchangeStream<NormalizedEvent, KucoinParser, KucoinSubscription>;
+
+    async fn stream_events(&self) -> Result<Self::EventStream, Self::Error> {
+        let parser = KucoinParser::new();
+        let mut stream = ExchangeStream::new(&self.base_url, None, parser, self.subscription.clone()).await?;
+        let res = stream.run().await;
+        if res.is_err() {
+            tracing::error!("Error running exchange stream: {:?}", res.err());
+        }
+        Ok(stream)
+    }
+}
+
+pub struct KucoinClientBuilder {
+    symbols: Vec<String>,
+    rest_endpoint: String,
+}
+
+impl Default for KucoinClientBuilder {
+    fn default() -> Self {
+        Self {
+            symbols: vec![],
+            rest_endpoint: "https://api.kucoin.com".to_string(),
+        }
+    }
+}
+
+impl KucoinClientBuilder {
+    pub fn add_symbols(mut self, symbols: Vec<impl Into<String>>) -> Self {
+        self.symbols.extend(symbols.into_iter().map(|s| s.into()));
+        self
+    }
+
+    pub fn with_rest_endpoint(mut self, ep: impl Into<String>) -> Self {
+        self.rest_endpoint = ep.into();
+        self
+    }
+
+    pub async fn build(self) -> eyre::Result<KucoinClient> {
+        #[derive(serde::Deserialize)]
+        struct BulletResp {
+            code: String,
+            data: BulletData,
+        }
+        #[derive(serde::Deserialize)]
+        struct BulletData {
+            token: String,
+            #[serde(rename = "instanceServers")]
+            instance_servers: Vec<InstanceServer>,
+        }
+        #[derive(serde::Deserialize)]
+        struct InstanceServer {
+            endpoint: String,
+            #[serde(rename = "pingInterval")]
+            ping_interval: u64,
+            #[serde(rename = "pingTimeout")]
+            ping_timeout: u64,
+        }
+
+        let client = reqwest::Client::new();
+        let resp: BulletResp = client
+            .post(format!("{}/api/v1/bullet-public", self.rest_endpoint))
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        let server = resp
+            .data
+            .instance_servers
+            .get(0)
+            .ok_or_else(|| eyre::eyre!("no instance server"))?;
+        let connect_id = Uuid::new_v4();
+        let base_url = format!(
+            "{}?token={}&connectId={}",
+            server.endpoint.trim_end_matches('/'),
+            resp.data.token,
+            connect_id
+        );
+
+        let mut subscription = KucoinSubscription::new(Duration::from_millis(server.ping_interval));
+        subscription.add_markets(
+            self.symbols
+                .iter()
+                .map(|s| StreamSymbols {
+                    symbol: s.clone(),
+                    stream_type: StreamType::Trade,
+                })
+                .collect(),
+        );
+        subscription.add_markets(
+            self.symbols
+                .iter()
+                .map(|s| StreamSymbols {
+                    symbol: s.clone(),
+                    stream_type: StreamType::Quote,
+                })
+                .collect(),
+        );
+
+        Ok(KucoinClient { base_url, subscription })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use tokio::time::{timeout, Duration};
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_kucoin_stream_event() {
+        let client = KucoinClient::builder()
+            .add_symbols(vec![
+                "BTC-USDT", "ETH-USDT", "XRP-USDT", "BCH-USDT", "ADA-USDT",
+                "DOGE-USDT", "SOL-USDT", "DOT-USDT", "TRX-USDT", "LTC-USDT",
+            ])
+            .build()
+            .await
+            .unwrap();
+        let mut stream = client.stream_events().await.unwrap();
+
+        for _ in 0..50 {
+            let result = timeout(Duration::from_secs(10), stream.next()).await;
+            assert!(result.is_ok(), "timed out waiting for event");
+            let item = result.unwrap();
+            assert!(item.is_some(), "no event received");
+            assert!(item.unwrap().is_ok(), "event returned error");
+        }
+    }
+}

--- a/src/streams/kucoin/model.rs
+++ b/src/streams/kucoin/model.rs
@@ -1,0 +1,99 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    models::{ExchangeName, NormalizedQuote, NormalizedTrade, TradeSide},
+    streams::ExchangeStreamError,
+};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TradeData {
+    pub sequence: Option<String>,
+    pub price: String,
+    pub size: String,
+    pub side: String,
+    pub symbol: Option<String>,
+    pub time: u64,
+}
+
+impl TryInto<NormalizedTrade> for TradeData {
+    type Error = ExchangeStreamError;
+
+    fn try_into(self) -> Result<NormalizedTrade, Self::Error> {
+        let price = self.price.parse::<f64>().map_err(|e| {
+            ExchangeStreamError::MessageError(format!("Invalid price value: {e}"))
+        })?;
+        let size = self.size.parse::<f64>().map_err(|e| {
+            ExchangeStreamError::MessageError(format!("Invalid size value: {e}"))
+        })?;
+        let side = match self.side.as_str() {
+            "buy" => TradeSide::Buy,
+            "sell" => TradeSide::Sell,
+            other => {
+                return Err(ExchangeStreamError::MessageError(format!(
+                    "Unknown side: {}",
+                    other
+                )))
+            }
+        };
+        let symbol = self.symbol.unwrap_or_default();
+        Ok(NormalizedTrade::new(
+            ExchangeName::Kucoin,
+            &symbol,
+            self.time * 1000,
+            side,
+            price,
+            size,
+        ))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TickerData {
+    pub best_ask: String,
+    #[serde(rename = "bestAskSize")]
+    pub best_ask_size: String,
+    pub best_bid: String,
+    #[serde(rename = "bestBidSize")]
+    pub best_bid_size: String,
+    pub time: u64,
+    pub symbol: Option<String>,
+}
+
+impl TryInto<NormalizedQuote> for TickerData {
+    type Error = ExchangeStreamError;
+
+    fn try_into(self) -> Result<NormalizedQuote, Self::Error> {
+        let ask_price = self.best_ask.parse::<f64>().map_err(|e| {
+            ExchangeStreamError::MessageError(format!("Invalid ask price: {e}"))
+        })?;
+        let ask_amount = self.best_ask_size.parse::<f64>().map_err(|e| {
+            ExchangeStreamError::MessageError(format!("Invalid ask size: {e}"))
+        })?;
+        let bid_price = self.best_bid.parse::<f64>().map_err(|e| {
+            ExchangeStreamError::MessageError(format!("Invalid bid price: {e}"))
+        })?;
+        let bid_amount = self.best_bid_size.parse::<f64>().map_err(|e| {
+            ExchangeStreamError::MessageError(format!("Invalid bid size: {e}"))
+        })?;
+        let symbol = self.symbol.unwrap_or_default();
+        Ok(NormalizedQuote::new(
+            ExchangeName::Kucoin,
+            &symbol,
+            self.time * 1000,
+            ask_amount,
+            ask_price,
+            bid_price,
+            bid_amount,
+        ))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum KucoinMessage {
+    Trade { topic: String, subject: String, data: TradeData, #[serde(rename = "type")] typ: String },
+    Ticker { topic: String, subject: String, data: TickerData, #[serde(rename = "type")] typ: String },
+    Other { #[serde(rename = "type")] typ: String },
+}

--- a/src/streams/kucoin/model.rs
+++ b/src/streams/kucoin/model.rs
@@ -8,27 +8,40 @@ use crate::{
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TradeData {
-    pub sequence: Option<String>,
+    pub maker_order_id: String,
+    pub taker_order_id: String,
+    pub sequence: String,
     pub price: String,
     pub size: String,
     pub side: String,
-    pub symbol: Option<String>,
-    pub time: u64,
+    pub symbol: String,
+    pub time: String,
+    pub trade_id: String,
 }
 
-impl TryInto<NormalizedTrade> for TradeData {
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TradeEvent {
+    pub topic: String,
+    pub subject: String,
+    pub data: TradeData,
+    #[serde(rename = "type")]
+    pub typ: String,
+}
+
+impl TryInto<NormalizedTrade> for TradeEvent {
     type Error = ExchangeStreamError;
 
     fn try_into(self) -> Result<NormalizedTrade, Self::Error> {
         let price = self
-            .price
+            .data.price
             .parse::<f64>()
             .map_err(|e| ExchangeStreamError::MessageError(format!("Invalid price value: {e}")))?;
         let size = self
-            .size
+            .data.size
             .parse::<f64>()
             .map_err(|e| ExchangeStreamError::MessageError(format!("Invalid size value: {e}")))?;
-        let side = match self.side.as_str() {
+        let side = match self.data.side.as_str() {
             "buy" => TradeSide::Buy,
             "sell" => TradeSide::Sell,
             other => {
@@ -38,11 +51,16 @@ impl TryInto<NormalizedTrade> for TradeData {
                 )));
             }
         };
-        let symbol = self.symbol.unwrap_or_default();
+
+        let timestamp = self
+            .data.time
+            .parse::<u64>()
+            .map_err(|e| ExchangeStreamError::MessageError(format!("Invalid time value: {e}")))?;
+
         Ok(NormalizedTrade::new(
             ExchangeName::Kucoin,
-            &symbol,
-            self.time * 1000,
+            &self.data.symbol,
+            timestamp / 1000,
             side,
             price,
             size,
@@ -54,40 +72,54 @@ impl TryInto<NormalizedTrade> for TradeData {
 #[serde(rename_all = "camelCase")]
 pub struct TickerData {
     pub best_ask: String,
-    #[serde(rename = "bestAskSize")]
     pub best_ask_size: String,
     pub best_bid: String,
-    #[serde(rename = "bestBidSize")]
     pub best_bid_size: String,
     pub time: u64,
-    pub symbol: Option<String>,
+    pub price: String,
+    pub sequence: String,
 }
 
-impl TryInto<NormalizedQuote> for TickerData {
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TickerEvent {
+    pub topic: String,
+    pub subject: String,
+    pub data: TickerData,
+    #[serde(rename = "type")]
+    pub typ: String,
+}
+
+impl TryInto<NormalizedQuote> for TickerEvent {
     type Error = ExchangeStreamError;
 
     fn try_into(self) -> Result<NormalizedQuote, Self::Error> {
         let ask_price = self
-            .best_ask
+            .data.best_ask
             .parse::<f64>()
             .map_err(|e| ExchangeStreamError::MessageError(format!("Invalid ask price: {e}")))?;
         let ask_amount = self
-            .best_ask_size
+            .data.best_ask_size
             .parse::<f64>()
             .map_err(|e| ExchangeStreamError::MessageError(format!("Invalid ask size: {e}")))?;
         let bid_price = self
-            .best_bid
+            .data.best_bid
             .parse::<f64>()
             .map_err(|e| ExchangeStreamError::MessageError(format!("Invalid bid price: {e}")))?;
         let bid_amount = self
-            .best_bid_size
+            .data.best_bid_size
             .parse::<f64>()
             .map_err(|e| ExchangeStreamError::MessageError(format!("Invalid bid size: {e}")))?;
-        let symbol = self.symbol.unwrap_or_default();
+
+        let symbol = &self.topic
+            .split(':')
+            .nth(1)
+            .ok_or_else(|| ExchangeStreamError::MessageError("Invalid topic format".to_string()))?;
+
         Ok(NormalizedQuote::new(
             ExchangeName::Kucoin,
-            &symbol,
-            self.time * 1000,
+            symbol,
+            self.data.time * 1000,
             ask_amount,
             ask_price,
             bid_price,
@@ -97,24 +129,67 @@ impl TryInto<NormalizedQuote> for TickerData {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Ack {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub typ: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase", untagged)]
 pub enum KucoinMessage {
-    Trade {
-        topic: String,
-        subject: String,
-        data: TradeData,
-        #[serde(rename = "type")]
-        typ: String,
-    },
-    Ticker {
-        topic: String,
-        subject: String,
-        data: TickerData,
-        #[serde(rename = "type")]
-        typ: String,
-    },
+    Trade(TradeEvent),
+    Ticker(TickerEvent),
+    Ack(Ack),
     Other {
         #[serde(rename = "type")]
         typ: String,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kucoin_trade_message_parsing() {
+        let json = r#"{
+            "topic": "/market/match:UNI-USDT",
+            "type": "message",
+            "subject": "trade.l3match",
+            "data": {
+                "makerOrderId": "6843fb19a0c85100075a7978",
+                "price": "6.1223",
+                "sequence": "15489153933131777",
+                "side": "sell",
+                "size": "81.6209",
+                "symbol": "UNI-USDT",
+                "takerOrderId": "6843fb1d02a36d0007d32121",
+                "time": "1749285661147000000",
+                "tradeId": "15489153933131777",
+                "type": "match"
+            }
+        }"#;
+
+        let parsed: KucoinMessage = serde_json::from_str(json).expect("Failed to parse JSON");
+
+        match parsed {
+            KucoinMessage::Trade(event) => {
+                assert_eq!(event.topic, "/market/match:UNI-USDT");
+                assert_eq!(event.subject, "trade.l3match");
+                assert_eq!(event.typ, "message");
+                assert_eq!(event.data.symbol, "UNI-USDT");
+                assert_eq!(event.data.price, "6.1223");
+                assert_eq!(event.data.side, "sell");
+                assert_eq!(event.data.size, "81.6209");
+                assert_eq!(event.data.maker_order_id, "6843fb19a0c85100075a7978");
+                assert_eq!(event.data.taker_order_id, "6843fb1d02a36d0007d32121");
+                assert_eq!(event.data.time, "1749285661147000000");
+                assert_eq!(event.data.trade_id, "15489153933131777");
+                assert_eq!(event.data.sequence, "15489153933131777");
+            }
+            _ => panic!("Expected KucoinMessage::Trade variant, got {:?}", parsed),
+        }
+    }
 }

--- a/src/streams/kucoin/model.rs
+++ b/src/streams/kucoin/model.rs
@@ -20,12 +20,14 @@ impl TryInto<NormalizedTrade> for TradeData {
     type Error = ExchangeStreamError;
 
     fn try_into(self) -> Result<NormalizedTrade, Self::Error> {
-        let price = self.price.parse::<f64>().map_err(|e| {
-            ExchangeStreamError::MessageError(format!("Invalid price value: {e}"))
-        })?;
-        let size = self.size.parse::<f64>().map_err(|e| {
-            ExchangeStreamError::MessageError(format!("Invalid size value: {e}"))
-        })?;
+        let price = self
+            .price
+            .parse::<f64>()
+            .map_err(|e| ExchangeStreamError::MessageError(format!("Invalid price value: {e}")))?;
+        let size = self
+            .size
+            .parse::<f64>()
+            .map_err(|e| ExchangeStreamError::MessageError(format!("Invalid size value: {e}")))?;
         let side = match self.side.as_str() {
             "buy" => TradeSide::Buy,
             "sell" => TradeSide::Sell,
@@ -33,7 +35,7 @@ impl TryInto<NormalizedTrade> for TradeData {
                 return Err(ExchangeStreamError::MessageError(format!(
                     "Unknown side: {}",
                     other
-                )))
+                )));
             }
         };
         let symbol = self.symbol.unwrap_or_default();
@@ -65,18 +67,22 @@ impl TryInto<NormalizedQuote> for TickerData {
     type Error = ExchangeStreamError;
 
     fn try_into(self) -> Result<NormalizedQuote, Self::Error> {
-        let ask_price = self.best_ask.parse::<f64>().map_err(|e| {
-            ExchangeStreamError::MessageError(format!("Invalid ask price: {e}"))
-        })?;
-        let ask_amount = self.best_ask_size.parse::<f64>().map_err(|e| {
-            ExchangeStreamError::MessageError(format!("Invalid ask size: {e}"))
-        })?;
-        let bid_price = self.best_bid.parse::<f64>().map_err(|e| {
-            ExchangeStreamError::MessageError(format!("Invalid bid price: {e}"))
-        })?;
-        let bid_amount = self.best_bid_size.parse::<f64>().map_err(|e| {
-            ExchangeStreamError::MessageError(format!("Invalid bid size: {e}"))
-        })?;
+        let ask_price = self
+            .best_ask
+            .parse::<f64>()
+            .map_err(|e| ExchangeStreamError::MessageError(format!("Invalid ask price: {e}")))?;
+        let ask_amount = self
+            .best_ask_size
+            .parse::<f64>()
+            .map_err(|e| ExchangeStreamError::MessageError(format!("Invalid ask size: {e}")))?;
+        let bid_price = self
+            .best_bid
+            .parse::<f64>()
+            .map_err(|e| ExchangeStreamError::MessageError(format!("Invalid bid price: {e}")))?;
+        let bid_amount = self
+            .best_bid_size
+            .parse::<f64>()
+            .map_err(|e| ExchangeStreamError::MessageError(format!("Invalid bid size: {e}")))?;
         let symbol = self.symbol.unwrap_or_default();
         Ok(NormalizedQuote::new(
             ExchangeName::Kucoin,
@@ -93,7 +99,22 @@ impl TryInto<NormalizedQuote> for TickerData {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase", untagged)]
 pub enum KucoinMessage {
-    Trade { topic: String, subject: String, data: TradeData, #[serde(rename = "type")] typ: String },
-    Ticker { topic: String, subject: String, data: TickerData, #[serde(rename = "type")] typ: String },
-    Other { #[serde(rename = "type")] typ: String },
+    Trade {
+        topic: String,
+        subject: String,
+        data: TradeData,
+        #[serde(rename = "type")]
+        typ: String,
+    },
+    Ticker {
+        topic: String,
+        subject: String,
+        data: TickerData,
+        #[serde(rename = "type")]
+        typ: String,
+    },
+    Other {
+        #[serde(rename = "type")]
+        typ: String,
+    },
 }

--- a/src/streams/kucoin/parser.rs
+++ b/src/streams/kucoin/parser.rs
@@ -21,16 +21,20 @@ impl Parser<NormalizedEvent> for KucoinParser {
             .map_err(|e| ExchangeStreamError::MessageError(format!("Failed to parse JSON: {e}")))?;
 
         match value {
-            KucoinMessage::Trade { data, .. } => {
-                let trade: NormalizedTrade = data.try_into()?;
+            KucoinMessage::Trade(event) => {
+                let trade: NormalizedTrade = event.try_into()?;
                 Ok(Some(NormalizedEvent::Trade(trade)))
             }
-            KucoinMessage::Ticker { data, .. } => {
-                let quote: NormalizedQuote = data.try_into()?;
+            KucoinMessage::Ticker(event) => {
+                let quote: NormalizedQuote = event.try_into()?;
                 Ok(Some(NormalizedEvent::Quote(quote)))
             }
+            KucoinMessage::Ack(event) => {
+                tracing::debug!("received kucoin ack: {}", event.id);
+                Ok(None)
+            }
             KucoinMessage::Other { .. } => {
-                tracing::debug!("received unhandled kucoin message: {}", text);
+                tracing::warn!("received unhandled kucoin message: {}", text);
                 Ok(None)
             }
         }

--- a/src/streams/kucoin/parser.rs
+++ b/src/streams/kucoin/parser.rs
@@ -1,8 +1,8 @@
+use super::model::KucoinMessage;
 use crate::{
-    models::{NormalizedEvent, NormalizedTrade, NormalizedQuote},
+    models::{NormalizedEvent, NormalizedQuote, NormalizedTrade},
     streams::{ExchangeStreamError, Parser},
 };
-use super::model::KucoinMessage;
 
 #[derive(Debug, Clone)]
 pub struct KucoinParser {}
@@ -17,9 +17,8 @@ impl Parser<NormalizedEvent> for KucoinParser {
     type Error = ExchangeStreamError;
 
     fn parse(&self, text: &str) -> Result<Option<NormalizedEvent>, Self::Error> {
-        let value: KucoinMessage = serde_json::from_str(text).map_err(|e| {
-            ExchangeStreamError::MessageError(format!("Failed to parse JSON: {e}"))
-        })?;
+        let value: KucoinMessage = serde_json::from_str(text)
+            .map_err(|e| ExchangeStreamError::MessageError(format!("Failed to parse JSON: {e}")))?;
 
         match value {
             KucoinMessage::Trade { data, .. } => {

--- a/src/streams/kucoin/parser.rs
+++ b/src/streams/kucoin/parser.rs
@@ -1,0 +1,39 @@
+use crate::{
+    models::{NormalizedEvent, NormalizedTrade, NormalizedQuote},
+    streams::{ExchangeStreamError, Parser},
+};
+use super::model::KucoinMessage;
+
+#[derive(Debug, Clone)]
+pub struct KucoinParser {}
+
+impl KucoinParser {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Parser<NormalizedEvent> for KucoinParser {
+    type Error = ExchangeStreamError;
+
+    fn parse(&self, text: &str) -> Result<Option<NormalizedEvent>, Self::Error> {
+        let value: KucoinMessage = serde_json::from_str(text).map_err(|e| {
+            ExchangeStreamError::MessageError(format!("Failed to parse JSON: {e}"))
+        })?;
+
+        match value {
+            KucoinMessage::Trade { data, .. } => {
+                let trade: NormalizedTrade = data.try_into()?;
+                Ok(Some(NormalizedEvent::Trade(trade)))
+            }
+            KucoinMessage::Ticker { data, .. } => {
+                let quote: NormalizedQuote = data.try_into()?;
+                Ok(Some(NormalizedEvent::Quote(quote)))
+            }
+            KucoinMessage::Other { .. } => {
+                tracing::debug!("received unhandled kucoin message: {}", text);
+                Ok(None)
+            }
+        }
+    }
+}

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -1,5 +1,6 @@
 pub mod binance;
 pub mod bybit;
+pub mod kucoin;
 pub mod exchange_stream;
 pub mod subscription;
 

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -1,7 +1,7 @@
 pub mod binance;
 pub mod bybit;
-pub mod kucoin;
 pub mod exchange_stream;
+pub mod kucoin;
 pub mod subscription;
 
 use crate::models::NormalizedEvent;

--- a/src/streams/subscription.rs
+++ b/src/streams/subscription.rs
@@ -140,3 +140,75 @@ impl Subscription for BybitSubscription {
         Some(Duration::from_secs(20))
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct KucoinSubscription {
+    symbols: Vec<StreamSymbols>,
+    ping_interval: Duration,
+}
+
+impl KucoinSubscription {
+    pub fn new(ping_interval: Duration) -> Self {
+        Self { symbols: vec![], ping_interval }
+    }
+
+    pub fn add_markets(&mut self, markets: Vec<StreamSymbols>) {
+        self.symbols.extend(markets);
+    }
+}
+
+impl Subscription for KucoinSubscription {
+    fn to_json(&self) -> Result<Vec<serde_json::Value>, serde_json::Error> {
+        #[derive(Serialize)]
+        struct SubscriptionMessage {
+            id: String,
+            #[serde(rename = "type")]
+            typ: &'static str,
+            topic: String,
+            #[serde(rename = "privateChannel")]
+            private_channel: bool,
+            response: bool,
+        }
+
+        let msgs = self
+            .symbols
+            .iter()
+            .map(|m| {
+                let topic_type = match m.stream_type {
+                    StreamType::Trade => "/market/match",
+                    StreamType::Quote => "/market/ticker",
+                };
+                let topic = format!("{}:{}", topic_type, m.symbol);
+                let msg = SubscriptionMessage {
+                    id: rand::random::<u64>().to_string(),
+                    typ: "subscribe",
+                    topic,
+                    private_channel: false,
+                    response: true,
+                };
+                serde_json::to_value(msg)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(msgs)
+    }
+
+    fn heartbeat(&self) -> Option<tokio_tungstenite::tungstenite::Message> {
+        #[derive(Serialize)]
+        struct PingMessage {
+            id: String,
+            #[serde(rename = "type")]
+            typ: &'static str,
+        }
+        let msg = PingMessage {
+            id: rand::random::<u64>().to_string(),
+            typ: "ping",
+        };
+        Some(tokio_tungstenite::tungstenite::Message::Text(
+            serde_json::to_string(&msg).unwrap().into(),
+        ))
+    }
+
+    fn heartbeat_interval(&self) -> Option<Duration> {
+        Some(self.ping_interval)
+    }
+}

--- a/src/streams/subscription.rs
+++ b/src/streams/subscription.rs
@@ -149,7 +149,10 @@ pub struct KucoinSubscription {
 
 impl KucoinSubscription {
     pub fn new(ping_interval: Duration) -> Self {
-        Self { symbols: vec![], ping_interval }
+        Self {
+            symbols: vec![],
+            ping_interval,
+        }
     }
 
     pub fn add_markets(&mut self, markets: Vec<StreamSymbols>) {

--- a/symbols.yaml
+++ b/symbols.yaml
@@ -116,3 +116,21 @@
     - UNI-USD
     - AAVE-USD
     - SUSHI-USD
+- exchange: "Kucoin"
+  market: "SPOT"
+  symbols:
+    - BTC-USDT
+    - ETH-USDT
+    - SOL-USDT
+    - LINK-USDT
+    - UNI-USDT
+    - AAVE-USDT
+    - SUSHI-USDT
+    - CRV-USDT
+    - GRT-USDT
+    - CAKE-USDT
+    - GMX-USDT
+    - MAGIC-USDT
+    - ARB-USDT
+    - PENDLE-USDT
+    - ANIME-USDT


### PR DESCRIPTION
## Summary
- add Kucoin websocket client and parser
- support kucoin subscription with heartbeat
- extend `ExchangeName` enum for Kucoin
- update Kucoin integration test to fetch 50 events across 10 symbols
- log Kucoin unrecognized messages for easier debugging
- clean up unused constant and fix subscription message field name

## Testing
- `cargo check`
- `cargo test --all-targets --no-run`


------
https://chatgpt.com/codex/tasks/task_e_684332f4e7c4832f9eb7b398410146c5