### PR TITLE
Stream single messages and batch in ClickHouse writer

### DIFF
--- a/src/ethereum.rs
+++ b/src/ethereum.rs
@@ -68,7 +68,7 @@ pub async fn fetch_blocks_task(
 ) -> eyre::Result<()> {
     let fetcher = BlockMetadataFetcher::new(rpc_url).await?;
     let block_stream = fetcher.create_block_metadata_stream().await;
-    let mut block_stream = block_stream.filter_map(|result| async move {
+    let block_stream = block_stream.filter_map(|result| async move {
         match result {
             Ok(block) => Some(ClickhouseMessage::Ethereum(EthereumMetadataMessage::Block(
                 block,

--- a/src/ethereum.rs
+++ b/src/ethereum.rs
@@ -64,27 +64,24 @@ impl BlockMetadataFetcher {
 
 pub async fn fetch_blocks_task(
     rpc_url: String,
-    msg_tx: mpsc::UnboundedSender<Vec<ClickhouseMessage>>,
+    msg_tx: mpsc::UnboundedSender<ClickhouseMessage>,
 ) -> eyre::Result<()> {
     let fetcher = BlockMetadataFetcher::new(rpc_url).await?;
     let block_stream = fetcher.create_block_metadata_stream().await;
-    let block_stream = block_stream
-        .filter_map(|result| async move {
-            match result {
-                Ok(block) => Some(ClickhouseMessage::Ethereum(EthereumMetadataMessage::Block(
-                    block,
-                ))),
-                Err(e) => {
-                    tracing::error!("Error in block stream: {:?}", e);
-                    None
-                }
+    let mut block_stream = block_stream.filter_map(|result| async move {
+        match result {
+            Ok(block) => Some(ClickhouseMessage::Ethereum(EthereumMetadataMessage::Block(
+                block,
+            ))),
+            Err(e) => {
+                tracing::error!("Error in block stream: {:?}", e);
+                None
             }
-        })
-        .chunks(10);
+        }
+    });
     pin_mut!(block_stream);
-    while let Some(chunk) = block_stream.next().await {
-        let res = msg_tx.send(chunk);
-        if res.is_err() {
+    while let Some(msg) = block_stream.next().await {
+        if msg_tx.send(msg).is_err() {
             tracing::error!("Failed to send block to channel");
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -310,7 +310,7 @@ async fn run_stream(args: StreamArgs) -> eyre::Result<()> {
 
     loop {
         // Create new channel for each restart cycle
-        let (msg_tx, msg_rx) = mpsc::unbounded_channel::<Vec<ClickhouseMessage>>();
+        let (msg_tx, msg_rx) = mpsc::unbounded_channel::<ClickhouseMessage>();
         let mut set = tokio::task::JoinSet::new();
 
         // Spawn tasks
@@ -322,14 +322,13 @@ async fn run_stream(args: StreamArgs) -> eyre::Result<()> {
                 .filter(|e| e.exchange.eq_ignore_ascii_case("binance"))
                 .flat_map(|e| e.symbols.iter().cloned().map(|s| s.to_lowercase()))
                 .collect();
-            let batch_size = args.batch_size;
             let tx = msg_tx.clone();
 
             tracing::info!("Spawning binance stream for symbols: {:?}", symbols);
             set.spawn(async move {
                 (
                     TaskType::BinanceStream,
-                    binance_stream_task(tx, symbols, batch_size).await,
+                    binance_stream_task(tx, symbols).await,
                 )
             });
         }
@@ -342,16 +341,10 @@ async fn run_stream(args: StreamArgs) -> eyre::Result<()> {
                 .filter(|e| e.exchange.eq_ignore_ascii_case("bybit"))
                 .flat_map(|e| e.symbols.iter().cloned())
                 .collect();
-            let batch_size = args.batch_size;
             let tx = msg_tx.clone();
 
             tracing::info!("Spawning bybit stream for symbols: {:?}", symbols);
-            set.spawn(async move {
-                (
-                    TaskType::BybitStream,
-                    bybit_stream_task(tx, symbols, batch_size).await,
-                )
-            });
+            set.spawn(async move { (TaskType::BybitStream, bybit_stream_task(tx, symbols).await) });
         }
 
         if !args.skip_okx {
@@ -363,16 +356,10 @@ async fn run_stream(args: StreamArgs) -> eyre::Result<()> {
                 .flat_map(|e| e.symbols.iter().cloned())
                 .collect();
 
-            let batch_size = args.batch_size;
             let tx = msg_tx.clone();
 
             tracing::info!("Spawning okx stream for symbols: {:?}", symbols);
-            set.spawn(async move {
-                (
-                    TaskType::OkxStream,
-                    okx_stream_task(tx, symbols, batch_size).await,
-                )
-            });
+            set.spawn(async move { (TaskType::OkxStream, okx_stream_task(tx, symbols).await) });
         }
 
         if !args.skip_coinbase {
@@ -383,14 +370,13 @@ async fn run_stream(args: StreamArgs) -> eyre::Result<()> {
                 .filter(|e| e.exchange.eq_ignore_ascii_case("coinbase"))
                 .flat_map(|e| e.symbols.iter().cloned())
                 .collect();
-            let batch_size = args.batch_size;
             let tx = msg_tx.clone();
 
             tracing::info!("Spawning coinbase stream for symbols: {:?}", symbols);
             set.spawn(async move {
                 (
                     TaskType::CoinbaseStream,
-                    coinbase_stream_task(tx, symbols, batch_size).await,
+                    coinbase_stream_task(tx, symbols).await,
                 )
             });
         }
@@ -403,14 +389,13 @@ async fn run_stream(args: StreamArgs) -> eyre::Result<()> {
                 .filter(|e| e.exchange.eq_ignore_ascii_case("kraken"))
                 .flat_map(|e| e.symbols.iter().cloned())
                 .collect();
-            let batch_size = args.batch_size;
             let tx = msg_tx.clone();
 
             tracing::info!("Spawning kraken stream for symbols: {:?}", symbols);
             set.spawn(async move {
                 (
                     TaskType::KrakenStream,
-                    kraken_stream_task(tx, symbols, batch_size).await,
+                    kraken_stream_task(tx, symbols).await,
                 )
             });
         }
@@ -423,14 +408,13 @@ async fn run_stream(args: StreamArgs) -> eyre::Result<()> {
                 .filter(|e| e.exchange.eq_ignore_ascii_case("kucoin"))
                 .flat_map(|e| e.symbols.iter().cloned())
                 .collect();
-            let batch_size = args.batch_size;
             let tx = msg_tx.clone();
 
             tracing::info!("Spawning kucoin stream for symbols: {:?}", symbols);
             set.spawn(async move {
                 (
                     TaskType::KucoinStream,
-                    kucoin_stream_task(tx, symbols, batch_size).await,
+                    kucoin_stream_task(tx, symbols).await,
                 )
             });
         }
@@ -459,10 +443,11 @@ async fn run_stream(args: StreamArgs) -> eyre::Result<()> {
 
         if !args.skip_clickhouse {
             tracing::info!("Spawning clickhouse writer task");
+            let batch_size = args.batch_size;
             set.spawn(async move {
                 (
                     TaskType::ClickHouseInsert,
-                    clickhouse_writer_task(msg_rx).await,
+                    clickhouse_writer_task(msg_rx, batch_size).await,
                 )
             });
         }
@@ -561,224 +546,208 @@ async fn run_stream(args: StreamArgs) -> eyre::Result<()> {
 }
 
 async fn binance_stream_task(
-    evt_tx: mpsc::UnboundedSender<Vec<ClickhouseMessage>>,
+    evt_tx: mpsc::UnboundedSender<ClickhouseMessage>,
     symbols: Vec<String>,
-    batch_size: usize,
 ) -> eyre::Result<()> {
     let binance = BinanceClient::builder().add_symbols(symbols).build()?;
     let combined_stream = binance.stream_events().await?;
-    let chunks = combined_stream
-        .filter_map(
-            |event: Result<NormalizedEvent, ExchangeStreamError>| async move {
-                match event {
-                    Ok(NormalizedEvent::Trade(trade)) => {
-                        Some(ClickhouseMessage::Cex(NormalizedEvent::Trade(trade)))
-                    }
-                    Ok(NormalizedEvent::Quote(quote)) => {
-                        Some(ClickhouseMessage::Cex(NormalizedEvent::Quote(quote)))
-                    }
-                    Err(e) => {
-                        // TODO: handle error
-                        tracing::error!("Error streaming binance event: {:?}", e);
-                        None
-                    }
+    let stream = combined_stream.filter_map(
+        |event: Result<NormalizedEvent, ExchangeStreamError>| async move {
+            match event {
+                Ok(NormalizedEvent::Trade(trade)) => {
+                    Some(ClickhouseMessage::Cex(NormalizedEvent::Trade(trade)))
                 }
-            },
-        )
-        .chunks(batch_size);
-    pin_mut!(chunks);
-    while let Some(chunk) = chunks.next().await {
-        let res = evt_tx.send(chunk);
-        if res.is_err() {
-            tracing::error!("Failed to send chunk to channel");
+                Ok(NormalizedEvent::Quote(quote)) => {
+                    Some(ClickhouseMessage::Cex(NormalizedEvent::Quote(quote)))
+                }
+                Err(e) => {
+                    tracing::error!("Error streaming binance event: {:?}", e);
+                    None
+                }
+            }
+        },
+    );
+    pin_mut!(stream);
+    while let Some(msg) = stream.next().await {
+        if evt_tx.send(msg).is_err() {
+            tracing::error!("Failed to send message to channel");
         }
     }
     Ok(())
 }
 
 async fn bybit_stream_task(
-    evt_tx: mpsc::UnboundedSender<Vec<ClickhouseMessage>>,
+    evt_tx: mpsc::UnboundedSender<ClickhouseMessage>,
     symbols: Vec<String>,
-    batch_size: usize,
 ) -> eyre::Result<()> {
     let bybit = BybitClient::builder().add_symbols(symbols).build()?;
     let combined_stream = bybit.stream_events().await?;
-    let chunks = combined_stream
-        .filter_map(
-            |event: Result<NormalizedEvent, ExchangeStreamError>| async move {
-                match event {
-                    Ok(NormalizedEvent::Trade(trade)) => {
-                        Some(ClickhouseMessage::Cex(NormalizedEvent::Trade(trade)))
-                    }
-                    Ok(NormalizedEvent::Quote(quote)) => {
-                        Some(ClickhouseMessage::Cex(NormalizedEvent::Quote(quote)))
-                    }
-                    Err(e) => {
-                        tracing::error!("Error streaming bybit event: {:?}", e);
-                        None
-                    }
+    let stream = combined_stream.filter_map(
+        |event: Result<NormalizedEvent, ExchangeStreamError>| async move {
+            match event {
+                Ok(NormalizedEvent::Trade(trade)) => {
+                    Some(ClickhouseMessage::Cex(NormalizedEvent::Trade(trade)))
                 }
-            },
-        )
-        .chunks(batch_size);
-    pin_mut!(chunks);
-    while let Some(chunk) = chunks.next().await {
-        let res = evt_tx.send(chunk);
-        if res.is_err() {
-            tracing::error!("Failed to send chunk to channel");
+                Ok(NormalizedEvent::Quote(quote)) => {
+                    Some(ClickhouseMessage::Cex(NormalizedEvent::Quote(quote)))
+                }
+                Err(e) => {
+                    tracing::error!("Error streaming bybit event: {:?}", e);
+                    None
+                }
+            }
+        },
+    );
+    pin_mut!(stream);
+    while let Some(msg) = stream.next().await {
+        if evt_tx.send(msg).is_err() {
+            tracing::error!("Failed to send message to channel");
         }
     }
     Ok(())
 }
 
 async fn okx_stream_task(
-    evt_tx: mpsc::UnboundedSender<Vec<ClickhouseMessage>>,
+    evt_tx: mpsc::UnboundedSender<ClickhouseMessage>,
     symbols: Vec<String>,
-    batch_size: usize,
 ) -> eyre::Result<()> {
     let okx = OkxClient::builder().add_symbols(symbols).build()?;
     let combined_stream = okx.stream_events().await?;
-    let chunks = combined_stream
-        .filter_map(
-            |event: Result<NormalizedEvent, ExchangeStreamError>| async move {
-                match event {
-                    Ok(NormalizedEvent::Trade(trade)) => {
-                        Some(ClickhouseMessage::Cex(NormalizedEvent::Trade(trade)))
-                    }
-                    Ok(NormalizedEvent::Quote(quote)) => {
-                        Some(ClickhouseMessage::Cex(NormalizedEvent::Quote(quote)))
-                    }
-                    Err(e) => {
-                        tracing::error!("Error streaming okx event: {:?}", e);
-                        None
-                    }
+    let stream = combined_stream.filter_map(
+        |event: Result<NormalizedEvent, ExchangeStreamError>| async move {
+            match event {
+                Ok(NormalizedEvent::Trade(trade)) => {
+                    Some(ClickhouseMessage::Cex(NormalizedEvent::Trade(trade)))
                 }
-            },
-        )
-        .chunks(batch_size);
-    pin_mut!(chunks);
-    while let Some(chunk) = chunks.next().await {
-        let res = evt_tx.send(chunk);
-        if res.is_err() {
-            tracing::error!("Failed to send chunk to channel");
+                Ok(NormalizedEvent::Quote(quote)) => {
+                    Some(ClickhouseMessage::Cex(NormalizedEvent::Quote(quote)))
+                }
+                Err(e) => {
+                    tracing::error!("Error streaming okx event: {:?}", e);
+                    None
+                }
+            }
+        },
+    );
+    pin_mut!(stream);
+    while let Some(msg) = stream.next().await {
+        if evt_tx.send(msg).is_err() {
+            tracing::error!("Failed to send message to channel");
         }
     }
     Ok(())
 }
 
 async fn coinbase_stream_task(
-    evt_tx: mpsc::UnboundedSender<Vec<ClickhouseMessage>>,
+    evt_tx: mpsc::UnboundedSender<ClickhouseMessage>,
     symbols: Vec<String>,
-    batch_size: usize,
 ) -> eyre::Result<()> {
     let coinbase = CoinbaseClient::builder().add_symbols(symbols).build()?;
     let combined_stream = coinbase.stream_events().await?;
-    let chunks = combined_stream
-        .filter_map(
-            |event: Result<NormalizedEvent, ExchangeStreamError>| async move {
-                match event {
-                    Ok(NormalizedEvent::Trade(trade)) => {
-                        Some(ClickhouseMessage::Cex(NormalizedEvent::Trade(trade)))
-                    }
-                    Ok(NormalizedEvent::Quote(quote)) => {
-                        Some(ClickhouseMessage::Cex(NormalizedEvent::Quote(quote)))
-                    }
-                    Err(e) => {
-                        tracing::error!("Error streaming coinbase event: {:?}", e);
-                        None
-                    }
+    let stream = combined_stream.filter_map(
+        |event: Result<NormalizedEvent, ExchangeStreamError>| async move {
+            match event {
+                Ok(NormalizedEvent::Trade(trade)) => {
+                    Some(ClickhouseMessage::Cex(NormalizedEvent::Trade(trade)))
                 }
-            },
-        )
-        .chunks(batch_size);
-    pin_mut!(chunks);
-    while let Some(chunk) = chunks.next().await {
-        let res = evt_tx.send(chunk);
-        if res.is_err() {
-            tracing::error!("Failed to send chunk to channel");
+                Ok(NormalizedEvent::Quote(quote)) => {
+                    Some(ClickhouseMessage::Cex(NormalizedEvent::Quote(quote)))
+                }
+                Err(e) => {
+                    tracing::error!("Error streaming coinbase event: {:?}", e);
+                    None
+                }
+            }
+        },
+    );
+    pin_mut!(stream);
+    while let Some(msg) = stream.next().await {
+        if evt_tx.send(msg).is_err() {
+            tracing::error!("Failed to send message to channel");
         }
     }
     Ok(())
 }
 
 async fn kraken_stream_task(
-    evt_tx: mpsc::UnboundedSender<Vec<ClickhouseMessage>>,
+    evt_tx: mpsc::UnboundedSender<ClickhouseMessage>,
     symbols: Vec<String>,
-    batch_size: usize,
 ) -> eyre::Result<()> {
     let kraken = KrakenClient::builder().add_symbols(symbols).build()?;
     let combined_stream = kraken.stream_events().await?;
-    let chunks = combined_stream
-        .filter_map(
-            |event: Result<NormalizedEvent, ExchangeStreamError>| async move {
-                match event {
-                    Ok(NormalizedEvent::Trade(trade)) => {
-                        Some(ClickhouseMessage::Cex(NormalizedEvent::Trade(trade)))
-                    }
-                    Ok(NormalizedEvent::Quote(quote)) => {
-                        Some(ClickhouseMessage::Cex(NormalizedEvent::Quote(quote)))
-                    }
-                    Err(e) => {
-                        tracing::error!("Error streaming kraken event: {:?}", e);
-                        None
-                    }
+    let stream = combined_stream.filter_map(
+        |event: Result<NormalizedEvent, ExchangeStreamError>| async move {
+            match event {
+                Ok(NormalizedEvent::Trade(trade)) => {
+                    Some(ClickhouseMessage::Cex(NormalizedEvent::Trade(trade)))
                 }
-            },
-        )
-        .chunks(batch_size);
-    pin_mut!(chunks);
-    while let Some(chunk) = chunks.next().await {
-        let res = evt_tx.send(chunk);
-        if res.is_err() {
-            tracing::error!("Failed to send chunk to channel");
+                Ok(NormalizedEvent::Quote(quote)) => {
+                    Some(ClickhouseMessage::Cex(NormalizedEvent::Quote(quote)))
+                }
+                Err(e) => {
+                    tracing::error!("Error streaming kraken event: {:?}", e);
+                    None
+                }
+            }
+        },
+    );
+    pin_mut!(stream);
+    while let Some(msg) = stream.next().await {
+        if evt_tx.send(msg).is_err() {
+            tracing::error!("Failed to send message to channel");
         }
     }
     Ok(())
 }
 
 async fn kucoin_stream_task(
-    evt_tx: mpsc::UnboundedSender<Vec<ClickhouseMessage>>,
+    evt_tx: mpsc::UnboundedSender<ClickhouseMessage>,
     symbols: Vec<String>,
-    batch_size: usize,
 ) -> eyre::Result<()> {
     let kucoin = KucoinClient::builder().add_symbols(symbols).build().await?;
     let combined_stream = kucoin.stream_events().await?;
-    let chunks = combined_stream
-        .filter_map(
-            |event: Result<NormalizedEvent, ExchangeStreamError>| async move {
-                match event {
-                    Ok(NormalizedEvent::Trade(trade)) => {
-                        Some(ClickhouseMessage::Cex(NormalizedEvent::Trade(trade)))
-                    }
-                    Ok(NormalizedEvent::Quote(quote)) => {
-                        Some(ClickhouseMessage::Cex(NormalizedEvent::Quote(quote)))
-                    }
-                    Err(e) => {
-                        tracing::error!("Error parsing event: {:?}", e);
-                        None
-                    }
+    let stream = combined_stream.filter_map(
+        |event: Result<NormalizedEvent, ExchangeStreamError>| async move {
+            match event {
+                Ok(NormalizedEvent::Trade(trade)) => {
+                    Some(ClickhouseMessage::Cex(NormalizedEvent::Trade(trade)))
                 }
-            },
-        )
-        .chunks(batch_size);
-    pin_mut!(chunks);
-    while let Some(chunk) = chunks.next().await {
-        let res = evt_tx.send(chunk);
-        if res.is_err() {
-            tracing::error!("Failed to send chunk to channel");
+                Ok(NormalizedEvent::Quote(quote)) => {
+                    Some(ClickhouseMessage::Cex(NormalizedEvent::Quote(quote)))
+                }
+                Err(e) => {
+                    tracing::error!("Error parsing event: {:?}", e);
+                    None
+                }
+            }
+        },
+    );
+    pin_mut!(stream);
+    while let Some(msg) = stream.next().await {
+        if evt_tx.send(msg).is_err() {
+            tracing::error!("Failed to send message to channel");
         }
     }
     Ok(())
 }
 
 async fn clickhouse_writer_task(
-    rx: mpsc::UnboundedReceiver<Vec<ClickhouseMessage>>,
+    mut rx: mpsc::UnboundedReceiver<ClickhouseMessage>,
+    batch_size: usize,
 ) -> eyre::Result<()> {
     let cfg = ClickHouseConfig::from_env()?;
     let clickhouse_svc = ClickHouseService::new(cfg);
-    pin_mut!(rx);
-    while let Some(batch) = rx.recv().await {
-        clickhouse_svc.handle_msg(batch).await?;
+    let mut buffer = Vec::with_capacity(batch_size);
+    while let Some(msg) = rx.recv().await {
+        buffer.push(msg);
+        if buffer.len() >= batch_size {
+            clickhouse_svc
+                .handle_msg(std::mem::take(&mut buffer))
+                .await?;
+        }
+    }
+    if !buffer.is_empty() {
+        clickhouse_svc.handle_msg(buffer).await?;
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -741,13 +741,12 @@ async fn clickhouse_writer_task(
     while let Some(msg) = rx.recv().await {
         buffer.push(msg);
         if buffer.len() >= batch_size {
-            clickhouse_svc
-                .handle_msg(std::mem::take(&mut buffer))
-                .await?;
+            let batch = std::mem::take(&mut buffer);
+            clickhouse_svc.handle_msg(&batch).await?;
         }
     }
     if !buffer.is_empty() {
-        clickhouse_svc.handle_msg(buffer).await?;
+        clickhouse_svc.handle_msg(&buffer).await?;
     }
     Ok(())
 }

--- a/src/streams/kraken/parser.rs
+++ b/src/streams/kraken/parser.rs
@@ -71,12 +71,12 @@ impl Parser<Vec<NormalizedEvent>> for KrakenParser {
                 Ok(None)
             }
             KrakenMessage::Subscription(sub_result) => {
-                if !sub_result.success
-                    && let Some(error) = sub_result.error
-                {
-                    return Err(ExchangeStreamError::Subscription(format!(
-                        "Subscription failed: {error}"
-                    )));
+                if !sub_result.success {
+                    if let Some(error) = sub_result.error {
+                        return Err(ExchangeStreamError::Subscription(format!(
+                            "Subscription failed: {error}"
+                        )));
+                    }
                 }
                 tracing::debug!("Subscription result: {:?}", sub_result);
                 Ok(None)


### PR DESCRIPTION
## Summary
- change channel to stream `ClickhouseMessage` instead of `Vec<ClickhouseMessage>`
- adjust all stream tasks to send individual messages
- accumulate batches inside `clickhouse_writer_task`
- rewrite unstable `let` expressions

## Testing
- `cargo check --quiet` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68454ac4b4dc832f9cf21e0505498fa8