### PR TITLE
Add MEXC exchange support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,7 @@ pub struct ExchangeConfigs {
     pub coinbase_symbols: Vec<String>,
     pub kraken_symbols: Vec<String>,
     pub kucoin_symbols: Vec<String>,
+    pub mexc_symbols: Vec<String>,
 }
 
 impl Default for AppConfig {
@@ -97,6 +98,7 @@ impl Default for ExchangeConfigs {
             coinbase_symbols: Vec::new(),
             kraken_symbols: Vec::new(),
             kucoin_symbols: Vec::new(),
+            mexc_symbols: Vec::new(),
         }
     }
 }
@@ -150,6 +152,7 @@ impl AppConfig {
             || !self.exchange_configs.coinbase_symbols.is_empty()
             || !self.exchange_configs.kraken_symbols.is_empty()
             || !self.exchange_configs.kucoin_symbols.is_empty()
+            || !self.exchange_configs.mexc_symbols.is_empty()
     }
 
     /// Create TaskManagerConfig from the current AppConfig
@@ -186,7 +189,13 @@ impl ExchangeConfigs {
             .filter(|e| e.exchange.eq_ignore_ascii_case("binance"))
             .filter(|e| e.trading_type.eq_ignore_ascii_case("spot"))
             // Binance accepts lowercase symbols only
-            .map(|e| format!("{}{}", e.base_asset.to_lowercase(), e.quote_asset.to_lowercase()))
+            .map(|e| {
+                format!(
+                    "{}{}",
+                    e.base_asset.to_lowercase(),
+                    e.quote_asset.to_lowercase()
+                )
+            })
             .collect();
 
         let bybit_symbols: Vec<String> = cfg
@@ -229,6 +238,14 @@ impl ExchangeConfigs {
             .map(|e| format!("{}-{}", e.base_asset, e.quote_asset))
             .collect();
 
+        let mexc_symbols: Vec<String> = cfg
+            .trading_pairs
+            .iter()
+            .filter(|e| e.exchange.eq_ignore_ascii_case("mexc"))
+            .filter(|e| e.trading_type.eq_ignore_ascii_case("spot"))
+            .map(|e| format!("{}{}", e.base_asset, e.quote_asset))
+            .collect();
+
         Self {
             binance_symbols,
             bybit_symbols,
@@ -236,6 +253,7 @@ impl ExchangeConfigs {
             coinbase_symbols,
             kraken_symbols,
             kucoin_symbols,
+            mexc_symbols,
         }
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -19,6 +19,8 @@ pub enum ExchangeName {
     Kucoin,
     #[serde(rename = "upbit")]
     Upbit,
+    #[serde(rename = "mexc")]
+    Mexc,
 }
 
 impl std::fmt::Display for ExchangeName {
@@ -31,6 +33,7 @@ impl std::fmt::Display for ExchangeName {
             ExchangeName::Kraken => write!(f, "kraken"),
             ExchangeName::Kucoin => write!(f, "kucoin"),
             ExchangeName::Upbit => write!(f, "upbit"),
+            ExchangeName::Mexc => write!(f, "mexc"),
         }
     }
 }

--- a/src/streams/mexc/mod.rs
+++ b/src/streams/mexc/mod.rs
@@ -1,0 +1,105 @@
+use async_trait::async_trait;
+use futures::stream::Stream;
+use std::pin::Pin;
+
+use crate::streams::mexc::parser::MexcParser;
+use crate::{
+    models::NormalizedEvent,
+    streams::{
+        ExchangeClient, ExchangeStreamError, StreamSymbols, StreamType, WebsocketStream,
+        exchange_stream::ExchangeStreamBuilder, subscription::MexcSubscription,
+    },
+};
+
+pub const DEFAULT_MEXC_WS_URL: &str = "wss://wbs-api.mexc.com/ws";
+
+pub mod model;
+pub mod parser;
+
+pub struct MexcClient {
+    base_url: String,
+    subscription: MexcSubscription,
+    symbols: Vec<String>,
+}
+
+impl MexcClient {
+    pub fn builder() -> MexcClientBuilder {
+        MexcClientBuilder::default()
+    }
+}
+
+#[async_trait]
+impl WebsocketStream for MexcClient {
+    type Error = ExchangeStreamError;
+    type EventStream =
+        Pin<Box<dyn Stream<Item = Result<NormalizedEvent, ExchangeStreamError>> + Send + 'static>>;
+
+    async fn stream_events(&self) -> Result<Self::EventStream, Self::Error> {
+        tracing::debug!("MEXC URL: {}", self.base_url);
+        let parser = MexcParser::new();
+        let stream =
+            ExchangeStreamBuilder::new(&self.base_url, None, parser, self.subscription.clone())
+                .build();
+        Ok(stream)
+    }
+}
+
+impl ExchangeClient for MexcClient {
+    fn get_exchange_name(&self) -> &'static str {
+        "mexc"
+    }
+
+    fn get_symbols(&self) -> &[String] {
+        &self.symbols
+    }
+}
+
+pub struct MexcClientBuilder {
+    symbols: Vec<String>,
+    base_url: String,
+}
+
+impl Default for MexcClientBuilder {
+    fn default() -> Self {
+        Self {
+            symbols: vec![],
+            base_url: DEFAULT_MEXC_WS_URL.to_string(),
+        }
+    }
+}
+
+impl MexcClientBuilder {
+    pub fn add_symbols(mut self, symbols: Vec<impl Into<String>>) -> Self {
+        self.symbols
+            .extend(symbols.into_iter().map(|s| s.into().to_uppercase()));
+        self
+    }
+
+    pub fn build(self) -> eyre::Result<MexcClient> {
+        let mut subscription = MexcSubscription::new();
+        subscription.add_markets(
+            self.symbols
+                .iter()
+                .map(|s| StreamSymbols {
+                    symbol: s.clone(),
+                    stream_type: StreamType::Trade,
+                })
+                .collect(),
+        );
+        subscription.add_markets(
+            self.symbols
+                .iter()
+                .map(|s| StreamSymbols {
+                    symbol: s.clone(),
+                    stream_type: StreamType::Quote,
+                })
+                .collect(),
+        );
+
+        Ok(MexcClient {
+            subscription,
+            base_url: self.base_url,
+            symbols: self.symbols,
+        })
+    }
+}

--- a/src/streams/mexc/model.rs
+++ b/src/streams/mexc/model.rs
@@ -1,0 +1,150 @@
+use arrayvec::ArrayString;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    models::{ExchangeName, NormalizedQuote, NormalizedTrade, TradeSide},
+    streams::ExchangeStreamError,
+};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Deal {
+    pub price: String,
+    pub quantity: String,
+    pub tradetype: u8,
+    pub time: u64,
+}
+
+impl TryFrom<Deal> for NormalizedTrade {
+    type Error = ExchangeStreamError;
+
+    fn try_from(d: Deal) -> Result<NormalizedTrade, Self::Error> {
+        let price = d
+            .price
+            .parse::<f64>()
+            .map_err(|e| ExchangeStreamError::Message(format!("Invalid price: {e}")))?;
+        let amount = d
+            .quantity
+            .parse::<f64>()
+            .map_err(|e| ExchangeStreamError::Message(format!("Invalid quantity: {e}")))?;
+        let side = match d.tradetype {
+            1 => TradeSide::Buy,
+            2 => TradeSide::Sell,
+            _ => {
+                return Err(ExchangeStreamError::Message(format!(
+                    "Unknown trade type: {}",
+                    d.tradetype
+                )));
+            }
+        };
+        Ok(NormalizedTrade::new(
+            ExchangeName::Mexc,
+            "", // symbol will be set by parent message
+            d.time * 1000,
+            side,
+            price,
+            amount,
+        ))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DealsData {
+    pub deals_list: Vec<Deal>,
+    pub eventtype: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TradeMessage {
+    pub channel: String,
+    pub publicdeals: DealsData,
+    pub symbol: String,
+    pub sendtime: u64,
+}
+
+impl TryFrom<TradeMessage> for Vec<NormalizedTrade> {
+    type Error = ExchangeStreamError;
+
+    fn try_from(msg: TradeMessage) -> Result<Vec<NormalizedTrade>, Self::Error> {
+        msg.publicdeals
+            .deals_list
+            .into_iter()
+            .map(|d| {
+                let mut trade: NormalizedTrade = d.try_into()?;
+                trade.symbol = ArrayString::<20>::from(&msg.symbol).unwrap();
+                Ok(trade)
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BookTickerData {
+    pub bidprice: String,
+    pub bidquantity: String,
+    pub askprice: String,
+    pub askquantity: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BookTickerMessage {
+    pub channel: String,
+    pub publicbookticker: BookTickerData,
+    pub symbol: String,
+    pub sendtime: u64,
+}
+
+impl TryFrom<BookTickerMessage> for NormalizedQuote {
+    type Error = ExchangeStreamError;
+
+    fn try_from(msg: BookTickerMessage) -> Result<NormalizedQuote, Self::Error> {
+        let bid_price = msg
+            .publicbookticker
+            .bidprice
+            .parse::<f64>()
+            .map_err(|e| ExchangeStreamError::Message(format!("Invalid bid price: {e}")))?;
+        let bid_amount = msg
+            .publicbookticker
+            .bidquantity
+            .parse::<f64>()
+            .map_err(|e| ExchangeStreamError::Message(format!("Invalid bid quantity: {e}")))?;
+        let ask_price = msg
+            .publicbookticker
+            .askprice
+            .parse::<f64>()
+            .map_err(|e| ExchangeStreamError::Message(format!("Invalid ask price: {e}")))?;
+        let ask_amount = msg
+            .publicbookticker
+            .askquantity
+            .parse::<f64>()
+            .map_err(|e| ExchangeStreamError::Message(format!("Invalid ask quantity: {e}")))?;
+        Ok(NormalizedQuote::new(
+            ExchangeName::Mexc,
+            &msg.symbol,
+            msg.sendtime * 1000,
+            ask_amount,
+            ask_price,
+            bid_price,
+            bid_amount,
+        ))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SubscriptionResponse {
+    pub id: Option<u64>,
+    pub code: i32,
+    pub msg: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum MexcMessage {
+    Trade(TradeMessage),
+    BookTicker(BookTickerMessage),
+    Ack(SubscriptionResponse),
+}

--- a/src/streams/mexc/parser.rs
+++ b/src/streams/mexc/parser.rs
@@ -1,0 +1,35 @@
+use crate::{
+    models::{NormalizedEvent, NormalizedTrade},
+    streams::{ExchangeStreamError, Parser, mexc::model::MexcMessage},
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct MexcParser;
+
+impl MexcParser {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Parser<Vec<NormalizedEvent>> for MexcParser {
+    type Error = ExchangeStreamError;
+
+    fn parse(&self, text: &str) -> Result<Option<Vec<NormalizedEvent>>, Self::Error> {
+        let msg: MexcMessage = serde_json::from_str(text)
+            .map_err(|e| ExchangeStreamError::Message(format!("Failed to parse JSON: {e}")))?;
+        match msg {
+            MexcMessage::Trade(trade_msg) => {
+                let trades: Vec<NormalizedTrade> = trade_msg.try_into()?;
+                Ok(Some(
+                    trades.into_iter().map(NormalizedEvent::Trade).collect(),
+                ))
+            }
+            MexcMessage::BookTicker(ticker_msg) => {
+                let quote = ticker_msg.try_into()?;
+                Ok(Some(vec![NormalizedEvent::Quote(quote)]))
+            }
+            MexcMessage::Ack(_) => Ok(None),
+        }
+    }
+}

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -4,6 +4,7 @@ pub mod coinbase;
 pub mod exchange_stream;
 pub mod kraken;
 pub mod kucoin;
+pub mod mexc;
 pub mod okx;
 pub mod subscription;
 // pub mod upbit; // TODO: Needs refactoring to use new builder pattern

--- a/tests/stream_test.rs
+++ b/tests/stream_test.rs
@@ -1,6 +1,6 @@
 use exc_clickhouse::streams::{
     WebsocketStream, binance::BinanceClient, bybit::BybitClient, coinbase::CoinbaseClient,
-    kraken::KrakenClient, kucoin::KucoinClient, okx::OkxClient,
+    kraken::KrakenClient, kucoin::KucoinClient, mexc::MexcClient, okx::OkxClient,
 };
 use futures::StreamExt;
 use tokio::time::{Duration, timeout};
@@ -204,6 +204,31 @@ async fn test_kucoin_stream_event() {
         ])
         .build()
         .await
+        .unwrap();
+    let mut stream = client.stream_events().await.unwrap();
+
+    let result = timeout(Duration::from_secs(10), async {
+        for _ in 0..30 {
+            let item = stream.next().await;
+            assert!(item.is_some(), "no event received");
+            assert!(item.unwrap().is_ok(), "event returned error");
+        }
+    })
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "timed out waiting for 30 events within 10 seconds"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_mexc_stream_event() {
+    init_tracing();
+    let client = MexcClient::builder()
+        .add_symbols(vec!["BTCUSDT", "ETHUSDT", "SOLUSDT", "XRPUSDT", "ADAUSDT"])
+        .build()
         .unwrap();
     let mut stream = client.stream_events().await.unwrap();
 


### PR DESCRIPTION
## Summary
- add MEXC client under `streams` with parser and models
- handle MEXC subscriptions
- support MEXC symbols in config
- spawn MEXC streaming task
- cover MEXC in integration tests

## Testing
- `cargo test --all --locked`

------
https://chatgpt.com/codex/tasks/task_e_68496b794244832f89c428702cae077d